### PR TITLE
chore: ignore UI node_modules and document setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Dependencies
 node_modules/
 */node_modules/
+apps/ui/node_modules/
 
 # Python
 __pycache__/

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -16,6 +16,15 @@ A React-based UI for the Entertainment Planner API with vibe selection and route
 - Node.js 16+ and npm
 - Entertainment Planner API running on port 8000
 
+## Setup
+
+Install dependencies:
+
+```bash
+cd apps/ui
+npm install
+```
+
 ## Quick Start
 
 ### 1. Start the API Server


### PR DESCRIPTION
## Summary
- ensure apps/ui/node_modules is ignored and not committed
- document npm install step in UI README

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `pytest` *(fails: ModuleNotFoundError for fastapi and requests; pip install -r requirements.txt failed with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b56bd64bf883279bdce7ba6a25e03f