### PR TITLE
Add environment template and contributing guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Example environment variables for Entertainment Planner
+
+# Cache TTL in days for the API cache layer
+WP_CACHE_TTL_DAYS=7
+
+# API key for OpenAI services used in ingestion scripts
+OPENAI_API_KEY=your_openai_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ wheels/
 .installed.cfg
 *.egg
 
+# Virtual environments
+.venv/
+venv/
+
 # Databases
 *.db
 *.sqlite
@@ -35,6 +39,9 @@ wheels/
 .env.development.local
 .env.test.local
 .env.production.local
+
+# Local configuration files
+*.local
 
 # IDE
 .vscode/
@@ -66,6 +73,13 @@ pids
 
 # Coverage directory used by tools like istanbul
 coverage/
+
+# Test and type artifacts
+.pytest_cache/
+.mypy_cache/
+.coverage
+coverage.xml
+htmlcov/
 
 # Temporary files
 *.tmp

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+Thank you for helping improve the Entertainment Planner project! This guide outlines how to work with the repository.
+
+## Development Workflow
+1. **Setup**
+   - Install dependencies with `python3 -m pip install -r requirements.txt`.
+   - Optionally copy `.env.example` to `.env` and adjust values for your local environment.
+2. **Run the data pipeline**
+   - Parse: `python3 apps/ingest/parsers/timeout_bkk.py --limit 5`
+   - Enrich: `python3 apps/ingest/enrich/run_enrich.py --limit 5 --city bangkok`
+   - Normalize: `python3 apps/ingest/normalize/normalizer.py --limit 10`
+   - Index: `python3 apps/ingest/index/build_index.py`
+3. **Start services**
+   - API: `cd apps/api && python3 main.py`
+   - UI: `cd apps/ui && npm start`
+
+## Scripts
+Key helper scripts live in the `scripts/` directory:
+
+| Script | Purpose |
+|-------|---------|
+| `init_db.sh` | Initialize the SQLite database |
+| `run_api.sh` | Start the FastAPI server |
+| `start_ui.sh` | Launch the React development server |
+| `run_tests.sh` | Execute the test suite across layers |
+
+Run any script with `bash scripts/<script>.sh`.
+
+## Coding Standards
+- Follow [PEP 8](https://peps.python.org/pep-0008/) and include type hints where possible.
+- Write tests for new functionality and run `bash scripts/run_tests.sh` before committing.
+- Keep commits focused and include descriptive messages.
+
+Happy hacking!


### PR DESCRIPTION
## Summary
- expand `.gitignore` for virtual envs, local configs, and test artifacts
- provide `.env.example` with cache and OpenAI placeholders
- document workflow and scripts in `docs/CONTRIBUTING.md`

## Testing
- `bash scripts/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68b56fa1f6a48327938d4f79b3e6e0e3