### PR TITLE
Remove sqlite3 dependency and document SQLite requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ python3 -m pip install -r requirements.txt
 python3 apps/ingest/db_init.py
 ```
 
+> **SQLite requirement:** The project relies on SQLite features such as FTS5. The
+> `sqlite3` module is included with Python, but ensure that your Python build is
+> linked against SQLite **3.9 or newer** so these features are available.
+
 ### 2. Run Data Pipeline
 ```bash
 # Parse TimeOut Bangkok data

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,5 @@ httpx==0.25.2
 mcp==1.0.0
 mcp-server-stdio==1.0.0
 mcp-server-websocket==1.0.0
-sqlite3
 beautifulsoup4==4.12.2
 requests==2.31.0


### PR DESCRIPTION
## Summary
- remove sqlite3 from requirements, relying on Python's built-in module
- document expected SQLite version and clarify no pip package needed

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy.)*

------
https://chatgpt.com/codex/tasks/task_e_68b56f87d86c83278d3e96a387b9d09b