### PR TITLE
Centralize database configuration with Pydantic settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ cd apps/ui && npm start
 bash scripts/run_tests.sh
 ```
 
+## Environment Variables
+
+- `DB_PATH` – path to the SQLite database. Defaults to `clean.db` in the project root.
+
 ## API Endpoints
 
 - `GET /api/health` - Health check with DB and FTS status

--- a/apps/api/cache.py
+++ b/apps/api/cache.py
@@ -5,6 +5,8 @@ import os
 from typing import Any, Dict, Optional, Tuple
 from datetime import datetime, timedelta
 
+from settings import settings
+
 class MemoryTTLCache:
     """In-memory TTL cache using dictionary"""
     
@@ -41,8 +43,8 @@ class MemoryTTLCache:
 
 class SQLiteCache:
     """SQLite-based persistent cache"""
-    
-    def __init__(self, db_path: str = "clean.db"):
+
+    def __init__(self, db_path: str = settings.db_path):
         self.db_path = db_path
         self._ensure_table_exists()
     
@@ -172,8 +174,8 @@ class SQLiteCache:
 
 class CacheManager:
     """Two-layer cache manager with memory and SQLite"""
-    
-    def __init__(self, db_path: str = "clean.db"):
+
+    def __init__(self, db_path: str = settings.db_path):
         self.memory_cache = MemoryTTLCache()
         self.sqlite_cache = SQLiteCache(db_path)
         self.default_ttl_days = int(os.getenv('WP_CACHE_TTL_DAYS', '7'))

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -14,6 +14,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 from packages.search.provider import LocalSearchProvider
 from cache import CacheManager
 from middleware import TimingMiddleware, log_operation
+from settings import settings
 
 app = FastAPI(title="Entertainment Planner API")
 
@@ -21,9 +22,8 @@ app = FastAPI(title="Entertainment Planner API")
 app.add_middleware(TimingMiddleware)
 
 # Initialize search provider and cache manager
-db_path = os.path.join(os.path.dirname(__file__), '..', '..', 'clean.db')
-search_provider = LocalSearchProvider(db_path)
-cache_manager = CacheManager(db_path)
+search_provider = LocalSearchProvider(settings.db_path)
+cache_manager = CacheManager(settings.db_path)
 
 # Feedback model
 class FeedbackRequest(BaseModel):
@@ -51,8 +51,7 @@ def haversine_distance(lat1: float, lng1: float, lat2: float, lng2: float) -> fl
 def get_place_by_id(place_id: int) -> Optional[Dict]:
     """Fetch place by ID from clean.places"""
     try:
-        db_path = os.path.join(os.path.dirname(__file__), '..', '..', 'clean.db')
-        conn = sqlite3.connect(db_path)
+        conn = sqlite3.connect(settings.db_path)
         cursor = conn.cursor()
         
         cursor.execute('''
@@ -203,8 +202,7 @@ async def health_check():
     # Check database connectivity
     db_status = "up"
     try:
-        db_path = os.path.join(os.path.dirname(__file__), '..', '..', 'clean.db')
-        conn = sqlite3.connect(db_path)
+        conn = sqlite3.connect(settings.db_path)
         cursor = conn.cursor()
         cursor.execute("SELECT COUNT(*) FROM places")
         conn.close()
@@ -214,8 +212,7 @@ async def health_check():
     # Check FTS status
     fts_status = "up"
     try:
-        db_path = os.path.join(os.path.dirname(__file__), '..', '..', 'clean.db')
-        conn = sqlite3.connect(db_path)
+        conn = sqlite3.connect(settings.db_path)
         cursor = conn.cursor()
         cursor.execute("SELECT COUNT(*) FROM fts_places")
         conn.close()
@@ -288,8 +285,7 @@ async def recommend_places(
     # Fetch full place data
     candidates = []
     try:
-        db_path = os.path.join(os.path.dirname(__file__), '..', '..', 'clean.db')
-        conn = sqlite3.connect(db_path)
+        conn = sqlite3.connect(settings.db_path)
         cursor = conn.cursor()
         
         placeholders = ','.join(['?' for _ in all_candidates])
@@ -458,8 +454,7 @@ async def warm_cache(
                     
                     # Fetch full place data
                     candidates = []
-                    db_path = os.path.join(os.path.dirname(__file__), '..', '..', 'clean.db')
-                    conn = sqlite3.connect(db_path)
+                    conn = sqlite3.connect(settings.db_path)
                     cursor = conn.cursor()
                     
                     if all_candidates:
@@ -560,8 +555,7 @@ async def submit_feedback(feedback: FeedbackRequest):
         log_operation("feedback_submit", route_ids=feedback.route, useful=feedback.useful, has_note=bool(feedback.note))
         
         # Store feedback in database
-        db_path = os.path.join(os.path.dirname(__file__), '..', '..', 'clean.db')
-        conn = sqlite3.connect(db_path)
+        conn = sqlite3.connect(settings.db_path)
         cursor = conn.cursor()
         
         # Create feedback table if it doesn't exist

--- a/packages/search/provider.py
+++ b/packages/search/provider.py
@@ -3,6 +3,8 @@ from typing import List, Tuple, Optional
 import sqlite3
 import json
 
+from settings import settings
+
 class SearchProvider(ABC):
     """Abstract interface for search providers"""
     
@@ -23,8 +25,8 @@ class SearchProvider(ABC):
 
 class LocalSearchProvider(SearchProvider):
     """Local search provider using FTS5 + deterministic embeddings"""
-    
-    def __init__(self, db_path: str = "clean.db"):
+
+    def __init__(self, db_path: str = settings.db_path):
         self.db_path = db_path
         self.embedding_dim = 64  # Fixed dimension for deterministic vectors
     

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+from pydantic import BaseSettings
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+    db_path: str = str(Path(__file__).resolve().parent / "clean.db")
+
+    class Config:
+        env_prefix = ''
+        env_file = '.env'
+
+settings = Settings()


### PR DESCRIPTION
## Summary
- add a `Settings` class for configuration
- use `settings.db_path` instead of hard-coded paths
- document `DB_PATH` environment variable in README

## Testing
- `pytest -q` *(fails: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68b56f93f8d8832785d62c2ca366f267