### PR TITLE
Add linting configuration and CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff bandit
+      - name: Run ruff
+        run: ruff .
+      - name: Run bandit
+        run: bandit -c bandit.yaml -r .
+
+  ui:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/ui
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run ESLint
+        run: npm run lint

--- a/apps/api/tests/test_recommend.py
+++ b/apps/api/tests/test_recommend.py
@@ -129,7 +129,7 @@ def test_health_endpoint():
     response = client.get("/api/health")
     assert response.status_code == 200
     data = response.json()
-    assert data["ok"] == True
+    assert data["ok"]
     assert "db" in data
     assert "fts" in data
     assert "X-Search" in response.headers

--- a/apps/ingest/index/indexer.py
+++ b/apps/ingest/index/indexer.py
@@ -90,7 +90,8 @@ class SearchIndexer:
         # Import search provider
         import sys
         sys.path.insert(0, str(Path(__file__).parent.parent.parent / 'packages' / 'search'))
-        import sys; sys.path.append("."); from packages.search.provider import LocalSearchProvider
+        sys.path.append(".")
+        from packages.search.provider import LocalSearchProvider
         
         provider = LocalSearchProvider(self.clean_db)
         

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -17,7 +17,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "eslint \"src/**/*.{ts,tsx}\" --max-warnings=0"
   },
   "eslintConfig": {
     "extends": [

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
 interface Place {
   id: number;

--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,0 +1,6 @@
+exclude_dirs:
+  - apps/ui
+  - apps/api/tests
+  - apps/ingest/tests
+skips:
+  - B101

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+extend-exclude = ["apps/ui/node_modules", "apps/ui/build", "apps/ui/dist"]
+
+[tool.ruff.lint]
+select = ["E", "F"]
+ignore = ["E501", "E722", "F401", "F841", "F541"]


### PR DESCRIPTION
## Summary
- configure ruff and bandit for Python codebase
- add UI lint script and clean up unused imports
- run linting in GitHub Actions for Python and frontend

## Testing
- `ruff check .`
- `npm run lint` (in `apps/ui`)
- `bandit -c bandit.yaml -r .` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b56f9b7b988327a368e6fdf83325eb