### PR TITLE
Handle empty recommendations

### DIFF
--- a/apps/api/tests/test_places_empty_candidates.py
+++ b/apps/api/tests/test_places_empty_candidates.py
@@ -1,0 +1,36 @@
+import os
+import uuid
+from importlib import reload
+
+import pytest
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / f"{uuid.uuid4().hex}.db"
+    os.environ["DB_PATH"] = str(db_path)
+
+    from apps.api import main
+    reload(main)
+
+    monkeypatch.setattr(main.search_provider, "fts", lambda q, k: [])
+    monkeypatch.setattr(main.search_provider, "knn", lambda q, k: [])
+
+    with TestClient(main.app) as client:
+        yield client
+
+    if db_path.exists():
+        db_path.unlink()
+
+
+def test_recommend_with_no_candidates_returns_404(client):
+    params = {
+        "vibe": "any",
+        "intents": "test",
+        "lat": 0.0,
+        "lng": 0.0,
+    }
+    response = client.get("/api/places/recommend", params=params)
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- Avoid invalid SQL in /api/places/recommend by returning 404 when no candidates are found and topping up only when needed
- Add regression test ensuring empty search results return 404 instead of querying with an empty IN clause

## Testing
- `pytest apps/api/tests/test_places_empty_candidates.py -q`
- `pytest tests/api/test_endpoints.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b59dae79f08327b747e5a71ce902c4